### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/deploy/linstor-scheduler.yaml
+++ b/deploy/linstor-scheduler.yaml
@@ -48,7 +48,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: k8s.gcr.io/kube-scheduler-amd64:v1.23.3
+          image: registry.k8s.io/kube-scheduler-amd64:v1.23.3
           imagePullPolicy: IfNotPresent
           startupProbe:
             failureThreshold: 24


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.