### PR TITLE
Fix empty namespace on pod handling

### DIFF
--- a/cmd/linstor-scheduler-admission/linstor-scheduler-admission.go
+++ b/cmd/linstor-scheduler-admission/linstor-scheduler-admission.go
@@ -53,7 +53,7 @@ func run(cli kubernetes.Interface) error {
 	cfg := initFlags()
 
 	// Create mutator.
-	mt := kwhmutating.MutatorFunc(func(ctx context.Context, _ *kwhmodel.AdmissionReview, obj metav1.Object) (*kwhmutating.MutatorResult, error) {
+	mt := kwhmutating.MutatorFunc(func(ctx context.Context, ar *kwhmodel.AdmissionReview, obj metav1.Object) (*kwhmutating.MutatorResult, error) {
 		pod, ok := obj.(*corev1.Pod)
 		if !ok {
 			return &kwhmutating.MutatorResult{}, nil
@@ -83,7 +83,7 @@ func run(cli kubernetes.Interface) error {
 		// Check PVCs
 		for _, pvcName := range pvcNames {
 			var discoveredProvisioner string
-			pvc, err := cli.CoreV1().PersistentVolumeClaims(pod.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
+			pvc, err := cli.CoreV1().PersistentVolumeClaims(ar.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				return &kwhmutating.MutatorResult{}, err
 			}


### PR DESCRIPTION
When creating an object in kubernetes, the namespace is not a required field. If it is not set, the namespace can be derived from the AdmissionReview.

Fixes https://github.com/kubevirt/kubevirt/issues/9578

The issue manifests itself like this:

```
Internal error occurred: failed calling webhook \"scheduler-admission.linstor.deckhouse.io\": failed to call webhook: an error on the server (\"{\\\"kind\\\":\\\"AdmissionReview\\\",\\\"apiVersion\\\":\\\"admission.k8s.io/v1\\\",\\\"response\\\":{\\\"uid\\\":\\\"e8677a78-aa94-4e2e-b021-8584786e1a4f\\\",\\\"allowed\\\":false,\\\"status\\\":{\\\"metadata\\\":{},\\\"status\\\":\\\"Failure\\\",\\\"message\\\":\\\"could not mutate object: an empty namespace may not be set when a resource name is provided\\\"}}}\") has prevented the request from succeeding"
```