### PR TITLE
fix(driver): skip UpToDate check for non-DRBD resources

### DIFF
--- a/pkg/driver/linstor.go
+++ b/pkg/driver/linstor.go
@@ -8,6 +8,7 @@ import (
 
 	lstor "github.com/LINBIT/golinstor"
 	lclient "github.com/LINBIT/golinstor/client"
+	"github.com/LINBIT/golinstor/devicelayerkind"
 	snapv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 	snapshotVolume "github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume"
 	storkvolume "github.com/libopenstorage/stork/drivers/volume"
@@ -134,6 +135,21 @@ func contains(a []string, e string) bool {
 	return false
 }
 
+// hasDRBDLayer reports whether the resource (or any nested layer) is built on top of DRBD.
+// Storage-only resources (e.g. single-replica ZFS without DRBD) do not have meaningful
+// DiskState reported, so the UpToDate check below must be skipped for them.
+func hasDRBDLayer(layer lclient.ResourceLayer) bool {
+	if layer.Type == devicelayerkind.Drbd {
+		return true
+	}
+	for _, c := range layer.Children {
+		if hasDRBDLayer(c) {
+			return true
+		}
+	}
+	return false
+}
+
 func (l *linstor) InspectVolume(volumeID string) (*storkvolume.Info, error) {
 	cli, err := l.linstorClient()
 	if err != nil {
@@ -153,11 +169,16 @@ func (l *linstor) InspectVolume(volumeID string) (*storkvolume.Info, error) {
 
 	var nodes []string
 	for _, r := range resources {
-		state := r.Volumes[0].State.DiskState
-		if state != "UpToDate" {
-			logrus.Debugf("Resource %s is not UpToDate on node %s, skipping (is %s)",
-				r.Name, r.NodeName, state)
-			continue
+		// DiskState semantics ("UpToDate", "Outdated", ...) are only meaningful when the
+		// resource is built on top of DRBD. Storage-only resources report an empty state
+		// because there is no DRBD device, so they were previously incorrectly filtered out.
+		if hasDRBDLayer(r.LayerObject) {
+			state := r.Volumes[0].State.DiskState
+			if state != "UpToDate" {
+				logrus.Debugf("Resource %s is not UpToDate on node %s, skipping (is %s)",
+					r.Name, r.NodeName, state)
+				continue
+			}
 		}
 
 		if contains(r.Flags, lstor.FlagDiskless) {


### PR DESCRIPTION
## Problem

`InspectVolume` filters out every candidate node whose `Volumes[0].State.DiskState`
is not `"UpToDate"`:

https://github.com/piraeusdatastore/linstor-scheduler-extender/blob/v0.3.2/pkg/driver/linstor.go#L156-L161

`DiskState` is only populated when the resource is built on top of a DRBD layer.
For **storage-only** resources (e.g. a single-replica ZFS volume created without
the DRBD layer) the field is reported as an empty string by the LINSTOR REST API.

As a result, pods backed by such resources are filtered out on every node and
stay `Pending` indefinitely, with the scheduler logging:

```
Resource <name> is not UpToDate on node <node>, skipping (is )
```

## Reproduction

1. Create a `LinstorResourceGroup`/`StorageClass` whose `LayerList` does **not**
   include `drbd` (e.g. `["storage"]` on top of a ZFS pool).
2. Create a PVC and a Pod that uses it.
3. Set `spec.schedulerName: linstor` (or rely on the
   `linstor-scheduler-admission` mutating webhook to inject it).
4. The Pod stays `Pending`. Scheduler debug logs contain the trailing empty
   `(is )` from the message above.

## Fix

Walk the resource's layer tree and only enforce the `UpToDate` check when a
DRBD layer is actually present. Behaviour for DRBD-replicated resources is
unchanged: `Outdated`/`Inconsistent`/etc. nodes are still skipped.

| Resource type           | Before  | After |
|-------------------------|---------|-------|
| DRBD `UpToDate`         | pass    | pass  |
| DRBD `Outdated` / other | skip    | skip  |
| Storage-only (no DRBD)  | **skip (bug)** | **pass** |

## Notes

- No new tests added — `pkg/driver` currently has no test suite.
- Build and `go vet ./...` pass.